### PR TITLE
Various updates to the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Conda needs to be installed on your system. Then:
 - create a conda environment (here it's called McDock)
 - activate the environment
 - install requirements (openbabel, RdKit, ASE, xTB (with python wrappers), numpy, xyz2mol)
-- xyz2mol also needs to be installed from source (from github)
+- xyz2mol also needs to be present locally (cloned from github) to fix a problem with reading xyz files
 
 copy paste the commands after the $ sign to your terminal
 
@@ -24,20 +24,34 @@ copy paste the commands after the $ sign to your terminal
 (McDock) $ conda install -c conda-forge xyz2mol
 ```
 
-To use xyz2mol clone the git repository:
+To fix and use xyz2mol clone the git repository:
 ```
 git clone https://github.com/jensengroup/xyz2mol
 ```
-cd into the directory and type `make`
+cd into the directory
 ```
 cd xyz2mol
+```
+Now, change line 550 of xyz2mol.py from
+```
+550                 atomic_symbol, x, y, z = line.split()
+```
+to
+```
+550                 atomic_symbol, x, y, z = line.split()[:4]
+```
+This is to fix a problem where the energies are included in the xyz file, causing the split to fail. We can safely ignore the energies since we recompute them anyway.
+
+Finally, type `make`
+```
 make
 ```
-This path is hardcoded wherever you install it. To run McDock you need to change line 157 in utils_rdkit.py to the path where you installed xyz2mol.
+
+The xyz2mol path is hardcoded wherever you cloned it. To run McDock you need to change line 158 in utils_rdkit.py to the path where you cloned the xyz2mol repository.
 ```
-157     cmd = "python ~/workcopies/xyz2mol/xyz2mol.py run_min.xyz -o sdf > run_min.sdf"
+158     cmd = "python ~/workcopies/xyz2mol/xyz2mol.py run_min.xyz -o sdf > run_min.sdf"
 ```
-change `~/workcopies/` to the path where you installed it!
+change `~/workcopies/` to the path where you cloned xyz2mol!
 
 ## Run mcDock
 Before running you need to change the memory default options of xTB using following command in your cmd line and also make a directory called directory:

--- a/README.md
+++ b/README.md
@@ -8,20 +8,23 @@ Conda needs to be installed on your system. Then:
 
 - create a conda environment (here it's called McDock)
 - activate the environment
-- install requirements (RdKit, ASE, xTB, numpy)
-- xyz2mol needs to be installed from source (from github)
+- install requirements (openbabel, RdKit, ASE, xTB (with python wrappers), numpy, xyz2mol)
+- xyz2mol also needs to be installed from source (from github)
 
 copy paste the commands after the $ sign to your terminal
 
 ```
 (base)   $ conda create -name McDock
 (base)   $ conda activate McDock
-(McDOck) $ conda install -c anaconda numpy
-(McDock) $ conda install -c conda-forge xtb
-(McDOck) $ conda install -c conda-forge ase
-(McDock) $ conda install -c rdkit rdki
+(McDock) $ conda install -c anaconda numpy
+(McDock) $ conda install -c conda-forge openbabel
+(McDock) $ conda install -c conda-forge xtb xtb-python
+(McDock) $ conda install -c conda-forge ase
+(McDock) $ conda install -c conda-forge rdkit
+(McDock) $ conda install -c conda-forge xyz2mol
 ```
-To install xyz2mol clone the git repository:
+
+To use xyz2mol clone the git repository:
 ```
 git clone https://github.com/jensengroup/xyz2mol
 ```
@@ -30,11 +33,11 @@ cd into the directory and type `make`
 cd xyz2mol
 make
 ```
-This path is hardcoded wherever you install it. To run McDock you need to change line 157 in utils_rdkit.py to the path where you isntalled xyz2mol
+This path is hardcoded wherever you install it. To run McDock you need to change line 157 in utils_rdkit.py to the path where you installed xyz2mol.
 ```
 157     cmd = "python ~/workcopies/xyz2mol/xyz2mol.py run_min.xyz -o sdf > run_min.sdf"
 ```
-change `~/workcopies/` to the path where you isntalled it!
+change `~/workcopies/` to the path where you installed it!
 
 ## Run mcDock
 Before running you need to change the memory default options of xTB using following command in your cmd line and also make a directory called directory:

--- a/utils_rdkit.py
+++ b/utils_rdkit.py
@@ -154,6 +154,7 @@ def minimize_molecule_xTB(mol):
 
     write("run_min.xyz", mol_ase)
 
+    # NOTE: replace '~/workcopies/' below with the path where you cloned the xyz2mol repository
     cmd = "python ~/workcopies/xyz2mol/xyz2mol.py run_min.xyz -o sdf > run_min.sdf"
     os.system(cmd)
 


### PR DESCRIPTION
When trying to run this locally, I discovered a couple of changes that seemed required. I have included them here in the hope that they might be useful to merge with your existing instructions.

Details:
  * Either xtb or rdkit seems to need `openbabel` installed.
  * The current version of `xtb` causes a "No module named 'xtb'" error unless `xtb-python` is installed along with it.
  * To get `rdkit` to work I had to use the more recent `conda-forge` channel version, otherwise conda complained that it could not solve the environment. The newer version seems compatible with the other dependencies.
  * I needed to have xyz2mol cloned _and_ installed via conda (something to do with module imports). I've also included a note on the line-split fix.
  
If there are mistakes that need fixing, or further changes required, before merging, please let me know and I will try to update this.